### PR TITLE
ch23018: Add the ability to install CircleCI services in private subnet

### DIFF
--- a/modules/nomad/outputs.tf
+++ b/modules/nomad/outputs.tf
@@ -1,15 +1,15 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.clients_asg.name}"
+  value = "${aws_autoscaling_group.clients_asg.*.name}"
 }
 
 output "client_security_group_name" {
-  value = "${aws_security_group.nomad_sg.name}"
+  value = "${aws_security_group.nomad_sg.*.name}"
 }
 
 output "ssh_security_group_name" {
-  value = "${aws_security_group.ssh_sg.name}"
+  value = "${aws_security_group.ssh_sg.*.name}"
 }
 
 output "client_launch_config_name" {
-  value = "${aws_launch_configuration.clients_lc.name}"
+  value = "${aws_launch_configuration.clients_lc.*.name}"
 }

--- a/templates/output.tpl
+++ b/templates/output.tpl
@@ -3,10 +3,10 @@ Your installation is complete. It may take several minutes until it is ready.
 
 "Continue the installation by visiting:"
 
-    http://${services_public_ip}:8800
+    http://${services_ip}:8800
 
 To ssh into the Services box of your installation using your `${ssh_key}` private key:
 
-    ssh ubuntu@${services_public_ip}
+    ssh ubuntu@${services_ip}
 
 Thank you and enjoy using CircleCI! 

--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -17,7 +17,7 @@ apt-get update && apt-get -y upgrade
 echo "--------------------------------------------"
 echo "       Setting Private IP"
 echo "--------------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export PRIVATE_IP="$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 
 echo "--------------------------------------------"
 echo "          Download Replicated"

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,11 @@ variable "legacy_builder_spot_price" {
   default = ""
 }
 
+variable "is_public" {
+  description = "Is the CircleCI services box public facing?"
+  default     = "true"
+}
+
 variable "ubuntu_ami" {
   default = {
     ap-northeast-1 = "ami-032b53ea1222f69eb"


### PR DESCRIPTION
Co-authored-by: Davide Gaspar <git@davidegaspar.com>

Update the forked CircleCI repo so that we can create the services CircleCI instance in the private subnet without exposing on the internet. This repository is cloned from `cnid-infrastructure` to deploy the CircleCI cluster