### PR TITLE
ch23098: Enable basic logging config for circleci

### DIFF
--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -24,6 +24,17 @@ apt-get install -y "linux-image-$UNAME"
 apt-get update
 apt-get -y install docker-ce=17.03.2~ce-0~ubuntu-xenial
 
+# Enable docker fluentd logging driver
+cat <<EOF > /etc/docker/daemon.json
+{
+  "log-driver": "fluentd",
+  "log-opts": {
+    "fluentd-address": "${nomad_server}:24224",
+    "fluentd-async-connect": "true"
+  }
+}
+EOF
+
 sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
 sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker
 sudo echo 'export no_proxy="${no_proxy}"' >> /etc/default/docker


### PR DESCRIPTION
- fluentd daemon running on services machine with docker driver
  defaulting to fluentd
- nomad worker nodes docker driver defaults to fluentd daemon
  running on the services machine
- allows fluentd access from worker nodes in security groups
- fluentd configuration is very minimial with output to stdout
  only, Change it to Elasticsearch when required

Co-authored-by: Davide Gaspar <git@davidegaspar.com>