### PR TITLE
FIX: use separate variable to override nomad client AMI and not use services AMI

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -384,7 +384,7 @@ module "nomad" {
   http_proxy            = "${var.http_proxy}"
   https_proxy           = "${var.https_proxy}"
   no_proxy              = "${var.no_proxy}"
-  ami_id                = "${(var.services_ami != "") ? var.services_ami : lookup(var.ubuntu_ami, var.aws_region)}"
+  ami_id                = "${(var.nomad_client_ami != "") ? var.nomad_client_ami : lookup(var.ubuntu_ami, var.aws_region)}"
   aws_subnet_cidr_block = "${data.aws_subnet.subnet.cidr_block}"
   services_private_ip   = "${aws_instance.services.private_ip}"
 }

--- a/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
+++ b/modules/nomad-cloudinit-ubuntu-v1/templates/nomad_user_data.tpl
@@ -52,7 +52,7 @@ mv nomad /usr/bin
 echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+export PRIVATE_IP="$(/usr/bin/curl -s $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
 export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,11 @@ variable "enable_nomad" {
   default     = 1
 }
 
+variable "nomad_client_ami" {
+  description = "Override Nomad Clients AMI lookup with provided AMI ID"
+  default     = ""
+}
+
 variable "nomad_client_instance_type" {
   description = "instance type for the nomad clients. It must be a valid aws instance type."
   default     = "m4.xlarge"


### PR DESCRIPTION
also fix retrieval of private IP address on the nomad clients to use metadata URL rather than ifconfig grepping