### PR TITLE
Adds telegraf configs and datadog api key var

### DIFF
--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -79,6 +79,23 @@ sudo service docker restart
 sleep 5
 ##### end fluentd configuration #####
 
+# telegraf configuration for custom monitoring
+cat <<EOF > /etc/circleconfig/telegraf/telegraf.conf
+[global_tags]
+  service = "circleci"
+  type = "server"
+  env = "${var.env}"
+EOF
+
+cat <<EOF > /etc/circleconfig/telegraf/datadog.conf
+[[outputs.datadog]]
+  apikey = "${var.datadog_api_key}"
+EOF
+
+sudo docker restart telegraf
+
+#end telegraf configuration
+
 echo "--------------------------------------------"
 echo "       Installing Replicated"
 echo "--------------------------------------------"

--- a/variables.tf
+++ b/variables.tf
@@ -148,4 +148,10 @@ variable "ubuntu_ami" {
   }
 }
 
+variable "datadog_api_key" {
+  description = "Datadog api key"
+}
 
+variable "env" {
+  description = "Environment"
+}


### PR DESCRIPTION
In order to enable circle ci advanced metrics, we need to add some configs for telegraf.

More info about advanced metrics [here](https://circleci.com/docs/2.0/monitoring/#advanced-system-monitoring)

You can view the dashboard [here](https://app.datadoghq.com/dash/1036979/circle-ci-enterprise?tile_size=m&page=0&is_auto=false&from_ts=1546878780000&to_ts=1546882380000&live=true)


Co-authored-by: Josh Michielsen <josh@jmickey.io>