### PR TITLE
FIX: create telegraf directory to handle first installation

### DIFF
--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -105,6 +105,9 @@ fi
 if [[ "${enable_telegraf_metrics}" == "true" ]];
 then
 
+# create directories to avoid failure on first installation
+mkdir -p /etc/circleconfig/telegraf
+
 cat <<EOF > /etc/circleconfig/telegraf/telegraf.conf
 [global_tags]
   service = "circleci"
@@ -117,7 +120,7 @@ cat <<EOF > /etc/circleconfig/telegraf/datadog.conf
   apikey = "${datadog_api_key}"
 EOF
 
-sudo docker restart telegraf
+sudo docker restart telegraf || echo "telegraf container doesnt exist"
 
 fi
 #end telegraf configuration


### PR DESCRIPTION
Fixes errors during initial bootstrap when CircleCI is not yet configured, so neither the telegraf container is running nor the configuration directories are present