### PR TITLE
[ZEN-74] Update telegraf global tags

### DIFF
--- a/templates/services_user_data.tpl
+++ b/templates/services_user_data.tpl
@@ -113,7 +113,7 @@ cat <<EOF > /etc/circleconfig/telegraf/telegraf.conf
   service = "circleci-server"
   app = "circleci"
   env = "${env}"
-  host = "circleci-svr-${env}"
+  host = "circleci-server-${env}"
 EOF
 
 cat <<EOF > /etc/circleconfig/telegraf/datadog.conf


### PR DESCRIPTION
Updated the global tags within the Telegraf container that forwards metrics to Datadog.