### PR TITLE
[LGH-42] Allow nomad client increase

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -395,6 +395,8 @@ module "nomad" {
   ami_id                = "${(var.nomad_client_ami != "") ? var.nomad_client_ami : lookup(var.ubuntu_ami, var.aws_region)}"
   aws_subnet_cidr_block = "${data.aws_subnet.subnet.cidr_block}"
   services_private_ip   = "${aws_instance.services.private_ip}"
+  desired_instances     = "${var.desired_nomad_instances}"
+  max_instances         = "${var.max_nomad_instances}"
 }
 
 output "success_message" {

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,14 @@ variable "enable_nomad" {
   default     = 1
 }
 
+variable "desired_nomad_instances" {
+  default = "1"
+}
+
+variable "max_nomad_instances" {
+  default = "2"
+}
+
 variable "nomad_client_ami" {
   description = "Override Nomad Clients AMI lookup with provided AMI ID"
   default     = ""


### PR DESCRIPTION
Added variables to able the user to specify the desired and max number of nomad client instances they with to specify in the autoscaling group.