### PR TITLE
Add cloud_plataform_tags variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -141,6 +141,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "cloud_platform_tags" {
+  type        = "map"
+  description = "cloud platform tagging policy"
+  default     = {}
+}
+
 variable "enable_fluentd_logging" {
   description = "Flag to enable fluentd logging"
   default     = "false"


### PR DESCRIPTION
In order for us to have a more atomic set of tags with our taggging policy we need to make this small change.

