### PR TITLE
LGH-162 removes desired capacity

### DIFF
--- a/circleci.tf
+++ b/circleci.tf
@@ -417,7 +417,6 @@ module "nomad" {
   ami_id                = "${(var.nomad_client_ami != "") ? var.nomad_client_ami : lookup(var.ubuntu_ami, var.aws_region)}"
   aws_subnet_cidr_block = "${data.aws_subnet.subnet.cidr_block}"
   services_private_ip   = "${aws_instance.services.private_ip}"
-  desired_instances     = "${var.desired_nomad_instances}"
   max_instances         = "${var.max_nomad_instances}"
   tags                  = "${var.tags}"
 }

--- a/modules/nomad/main.tf
+++ b/modules/nomad/main.tf
@@ -101,7 +101,6 @@ resource "aws_autoscaling_group" "clients_asg" {
   launch_configuration = "${aws_launch_configuration.clients_lc.name}"
   max_size             = "${var.max_instances}"
   min_size             = 0
-  desired_capacity     = "${var.desired_instances}"
   force_delete         = true
 
   tags = ["${data.null_data_source.tags.*.outputs}"]

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -32,10 +32,6 @@ variable "max_instances" {
   default = "2"
 }
 
-variable "desired_instances" {
-  default = "1"
-}
-
 variable "http_proxy" {}
 variable "https_proxy" {}
 variable "no_proxy" {}

--- a/variables.tf
+++ b/variables.tf
@@ -56,10 +56,6 @@ variable "enable_nomad" {
   default     = 1
 }
 
-variable "desired_nomad_instances" {
-  default = "1"
-}
-
 variable "max_nomad_instances" {
   default = "2"
 }


### PR DESCRIPTION
Because we currently have two autoscalling schedules responsible for changing this value we shouldn't be setting this. This will allow us to apply any terraform without impacting circleci jobs